### PR TITLE
Update build.gradle of the whole project

### DIFF
--- a/TrivialDrive_v2/base-feature/build.gradle
+++ b/TrivialDrive_v2/base-feature/build.gradle
@@ -29,7 +29,6 @@ android {
     baseFeature = true
 
     compileSdkVersion Integer.valueOf(project.TARGET_SDK_VERSION)
-    buildToolsVersion project.TOOLS_VERSION
 
     defaultConfig {
         // Tests with Google Play Billing APIs must use production package name.
@@ -62,8 +61,8 @@ dependencies {
     application project(':mobile')
     wearApp project(':wear')
 
-    androidTestApi('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testApi 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }

--- a/TrivialDrive_v2/build.gradle
+++ b/TrivialDrive_v2/build.gradle
@@ -66,7 +66,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha08'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha10'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/TrivialDrive_v2/build.gradle
+++ b/TrivialDrive_v2/build.gradle
@@ -44,9 +44,8 @@ project.ext {
     KEYSTORE_KEY_PASSWORD = keystoreProperties['keyPassword']
 
     MINIMUM_SDK_VERSION = 14
-    TARGET_SDK_VERSION = 27
-    TOOLS_VERSION = "27.0.3"
-    SUPPORT_VERSION = "27.0.2"
+    TARGET_SDK_VERSION = 28
+    SUPPORT_VERSION = "27.1.1"
 
     FEATURE_VERSION_CODE = 1
     FEATURE_VERSION_NAME = "1.01"
@@ -67,7 +66,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha08'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/TrivialDrive_v2/gradle/wrapper/gradle-wrapper.properties
+++ b/TrivialDrive_v2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/TrivialDrive_v2/gradle/wrapper/gradle-wrapper.properties
+++ b/TrivialDrive_v2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/TrivialDrive_v2/instant/build.gradle
+++ b/TrivialDrive_v2/instant/build.gradle
@@ -16,10 +16,6 @@
 
 apply plugin: 'com.android.instantapp'
 
-android {
-    buildToolsVersion project.TOOLS_VERSION
-}
-
 dependencies {
     implementation project(':base-feature')
 }

--- a/TrivialDrive_v2/mobile/build.gradle
+++ b/TrivialDrive_v2/mobile/build.gradle
@@ -26,7 +26,6 @@ android {
         }
     }
     compileSdkVersion Integer.valueOf(project.TARGET_SDK_VERSION)
-    buildToolsVersion project.TOOLS_VERSION
 
     defaultConfig {
         applicationId project.APP_ID

--- a/TrivialDrive_v2/shared-module/build.gradle
+++ b/TrivialDrive_v2/shared-module/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion Integer.valueOf(project.TARGET_SDK_VERSION)
-    buildToolsVersion project.TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion Integer.valueOf(MINIMUM_SDK_VERSION)
@@ -40,9 +39,9 @@ dependencies {
     api "com.android.support:recyclerview-v7:$project.SUPPORT_VERSION"
     api "com.android.support:support-annotations:$project.SUPPORT_VERSION"
 
-    androidTestApi 'com.android.support.test:testing-support-lib:0.1'
-    androidTestApi 'com.android.support.test.espresso:espresso-core:3.0.1'
-    testApi 'junit:junit:4.12'
-    testApi 'org.mockito:mockito-core:1.10.19'
-    testApi 'org.robolectric:robolectric:2.4'
+    androidTestImplementation 'com.android.support.test:testing-support-lib:0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.21.0'
+    testImplementation 'org.robolectric:robolectric:3.8'
 }

--- a/TrivialDrive_v2/tv/build.gradle
+++ b/TrivialDrive_v2/tv/build.gradle
@@ -26,7 +26,6 @@ android {
         }
     }
     compileSdkVersion Integer.valueOf(project.TARGET_SDK_VERSION)
-    buildToolsVersion project.TOOLS_VERSION
     defaultConfig {
         applicationId project.APP_ID
         // We need to hard-code 17 version here due to the leanback library

--- a/TrivialDrive_v2/wear/build.gradle
+++ b/TrivialDrive_v2/wear/build.gradle
@@ -26,7 +26,6 @@ android {
         }
     }
     compileSdkVersion Integer.valueOf(project.TARGET_SDK_VERSION)
-    buildToolsVersion project.TOOLS_VERSION
     defaultConfig {
         applicationId project.APP_ID
         minSdkVersion Integer.valueOf(project.MINIMUM_SDK_VERSION)
@@ -52,7 +51,7 @@ android {
 dependencies {
     implementation project(':shared-module')
 
-    compileOnly 'com.google.android.wearable:wearable:2.2.0'
-    implementation 'com.google.android.support:wearable:2.2.0'
-    implementation 'com.google.android.gms:play-services-wearable:11.8.0'
+    compileOnly 'com.google.android.wearable:wearable:2.3.0'
+    implementation 'com.google.android.support:wearable:2.3.0'
+    implementation 'com.google.android.gms:play-services-wearable:15.0.1'
 }

--- a/TrivialDrive_v2/wear/build.gradle
+++ b/TrivialDrive_v2/wear/build.gradle
@@ -48,6 +48,17 @@ android {
     }
 }
 
+configurations.all { configuration ->
+    resolutionStrategy {
+        force "com.android.support:percent:$SUPPORT_VERSION",
+                "com.android.support:cardview-v7:$SUPPORT_VERSION",
+                    "com.android.support:appcompat-v7:$SUPPORT_VERSION",
+                        "com.android.support:support-v4:$SUPPORT_VERSION",
+                        "com.android.support:support-media-compat:$SUPPORT_VERSION",
+                            "com.android.support:animated-vector-drawable:$SUPPORT_VERSION"
+    }
+}
+
 dependencies {
     implementation project(':shared-module')
 


### PR DESCRIPTION
- Target to api-level 28
- Remove build-tool options, it'd be taken while compiling automatically.
- Upgrade gradle-plugin
- Fix gradle dependency problem of  `wear`  module after upgrade to 27.1.1 .

Associated fix after this fixing:
#157  
#158