### PR TITLE
Do not hard code response code for RESULT_CANCELED

### DIFF
--- a/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/util/IabHelper.java
+++ b/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/util/IabHelper.java
@@ -586,7 +586,7 @@ public class IabHelper {
         }
         else if (resultCode == Activity.RESULT_CANCELED) {
             logDebug("Purchase canceled - Response: " + getResponseDesc(responseCode));
-            result = new IabResult(IABHELPER_USER_CANCELLED, "User canceled.");
+            result = new IabResult(responseCode, "User canceled.");
             if (mPurchaseListener != null) mPurchaseListener.onIabPurchaseFinished(result, null);
         }
         else {


### PR DESCRIPTION
When an Activity results in an `Activity.RESULT_CANCELED` result code, it is often because the user pressed Back or Cancel. However, it is not the case 100% of the time. Instead of calling the listener with a hardcoded `IABHELPER_USER_CANCELLED`  response code, we should call it with the actual `responseCode` from the Intent.