### PR TITLE
Changing Google Play Developer Api to v3

### DIFF
--- a/ClassyTaxi/firebase/server/src/play-billing/PlayBilling.ts
+++ b/ClassyTaxi/firebase/server/src/play-billing/PlayBilling.ts
@@ -67,7 +67,7 @@ export default class PlayBilling {
       null
     );
     const playDeveloperApiClient = google.androidpublisher({
-      version: 'v2',
+      version: 'v3',
       auth: jwtClient
     });
 


### PR DESCRIPTION
#244 Issue
I have changed the version of Google Play Api to V3 as V2 will no longer be available from December.
I think all other resources are same for version 3 compared to version 2 .