### PR TITLE
Add necessary dependencies for ClassyTaxi to build with JDK9+

### DIFF
--- a/ClassyTaxi/android/ClassyTaxi/app/build.gradle
+++ b/ClassyTaxi/android/ClassyTaxi/app/build.gradle
@@ -107,6 +107,19 @@ dependencies {
     // Kotlin annotation processor for Room.
     kapt "android.arch.persistence.room:compiler:$archRoomVersion"
 
+    // Necessary for compiling on environments running JDK9+
+    compileOnly "com.github.pengrad:jdk9-deps:$jdk9DepsVersion"
+
+    if (project.hasProperty('kapt')) {
+        kapt "javax.xml.bind:jaxb-api:$jaxbApiVersion"
+        kapt "com.sun.xml.bind:jaxb-core:$jaxbCoreVersion"
+        kapt "com.sun.xml.bind:jaxb-impl:$jaxbImpl"
+    }
+
+    annotationProcessor "javax.xml.bind:jaxb-api:$jaxbApiVersion"
+    annotationProcessor "com.sun.xml.bind:jaxb-core:$jaxbCoreVersion"
+    annotationProcessor "com.sun.xml.bind:jaxb-impl:$jaxbImpl"
+
     // Test dependencies.
     testImplementation "junit:junit:$jUnitVersion"
 }

--- a/ClassyTaxi/android/ClassyTaxi/app/build.gradle
+++ b/ClassyTaxi/android/ClassyTaxi/app/build.gradle
@@ -107,15 +107,16 @@ dependencies {
     // Kotlin annotation processor for Room.
     kapt "android.arch.persistence.room:compiler:$archRoomVersion"
 
-    // Necessary for compiling on environments running JDK9+
+    // The following rules are for compiling on environments running JDK9+.
+    // In this project, these rules are necessary because data binding is enabled. It fixes the
+    // error 'java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException' that occurs when
+    // the project is assembled through the command line with an environment running JDK9+.
     compileOnly "com.github.pengrad:jdk9-deps:$jdk9DepsVersion"
-
     if (project.hasProperty('kapt')) {
         kapt "javax.xml.bind:jaxb-api:$jaxbApiVersion"
         kapt "com.sun.xml.bind:jaxb-core:$jaxbCoreVersion"
         kapt "com.sun.xml.bind:jaxb-impl:$jaxbImpl"
     }
-
     annotationProcessor "javax.xml.bind:jaxb-api:$jaxbApiVersion"
     annotationProcessor "com.sun.xml.bind:jaxb-core:$jaxbCoreVersion"
     annotationProcessor "com.sun.xml.bind:jaxb-impl:$jaxbImpl"

--- a/ClassyTaxi/android/ClassyTaxi/build.gradle
+++ b/ClassyTaxi/android/ClassyTaxi/build.gradle
@@ -70,6 +70,12 @@ buildscript {
     ext.gradleToolsVersion = '3.4.1'
     ext.kotlinVersion = '1.3.11'
 
+    // jaxb versions for compiling for JDK9+
+    ext.jdk9DepsVersion = '1.0'
+    ext.jaxbApiVersion = '2.3.1'
+    ext.jaxbCoreVersion = '2.3.0.1'
+    ext.jaxbImpl = '2.3.2'
+
     // Testing versions.
     ext.jUnitVersion = '4.12'
 


### PR DESCRIPTION
This fixes the build error `java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException` when ClassyTaxi is compiled with JDK9+ 

cc @cartland 