### PR TITLE
Remove specifying build tools version

### DIFF
--- a/ClassyTaxi/android/ClassyTaxi/app/build.gradle
+++ b/ClassyTaxi/android/ClassyTaxi/app/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion androidCompileSdkVersion as Integer
-    buildToolsVersion androidBuildToolsVersion
     defaultConfig {
         // The applicationId should be set in the project gradle.properties files.
         applicationId androidApplicationId

--- a/ClassyTaxi/android/ClassyTaxi/build.gradle
+++ b/ClassyTaxi/android/ClassyTaxi/build.gradle
@@ -46,7 +46,6 @@ ext {
     androidMinimumSdkVersion = 17
     androidTargetSdkVersion = 28
     androidCompileSdkVersion = 28
-    androidBuildToolsVersion = '28.0.3'
 }
 
 buildscript {


### PR DESCRIPTION
Resolves https://github.com/android/play-billing-samples/issues/170 

Why build tools verison is not needed: 
https://developer.android.com/studio/releases/gradle-plugin.html#behavior_changes

> Starting in Android Studio 3.0 you no longer need to specify a version for the build tools (so, you can now remove the android.buildToolsVersion property). By default, the plugin automatically uses the minimum required build tools version for the version of Android plugin you're using.
