### PR TITLE
Update SKU title string with spannable in order to clear spannable data.

### DIFF
--- a/TrivialDriveJava/app/src/main/java/com/sample/android/trivialdrivesample/ui/MakePurchaseFragment.java
+++ b/TrivialDriveJava/app/src/main/java/com/sample/android/trivialdrivesample/ui/MakePurchaseFragment.java
@@ -150,7 +150,9 @@ public class MakePurchaseFragment extends Fragment {
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             result.setValue(titleSpannable);
         } else {
-            result.setValue(skuTitle);
+            // empty SpannableString needs to be used to clear spannables
+            SpannableString titleSpannable = new SpannableString(skuTitle);
+            result.setValue(titleSpannable);
         }
     }
 

--- a/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/ui/MakePurchaseFragment.java
+++ b/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/ui/MakePurchaseFragment.java
@@ -149,7 +149,9 @@ public class MakePurchaseFragment extends Fragment {
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             result.setValue(titleSpannable);
         } else {
-            result.setValue(skuTitle);
+            // empty SpannableString needs to be used to clear spannables
+            SpannableString titleSpannable = new SpannableString(skuTitle);
+            result.setValue(titleSpannable);
         }
     }
 


### PR DESCRIPTION
This fixes the issue where, when updgrading/downloading a subscription, the spannables remain.