### PR TITLE
Display a dialog instead of causing build to fail if no base64Encoded…

### DIFF
--- a/TrivialDriveJava/app/build.gradle
+++ b/TrivialDriveJava/app/build.gradle
@@ -28,13 +28,12 @@ android {
                                       "$projectDir/schemas".toString()]
             }
         }
-        if (localProperties['base64EncodedPublicKey']) {
-            buildConfigField("String", "BASE64_ENCODED_PUBLIC_KEY", "\"" + localProperties['base64EncodedPublicKey'] + "\"")
-        } else {
-            throw new GradleException('base64EncodedPublicKey must be set for signature verification.' +
-                                      'You can add it to local.properties once you have gotten it from Play.' +
-                                      'Example: base64EncodedPublicKey=[key value]')
+        if (!localProperties['base64EncodedPublicKey']) {
+            logger.warn('base64EncodedPublicKey must be set for signature verification. ' +
+                    'You can add it to local.properties once you have gotten it from Play. ' +
+                    'Example: base64EncodedPublicKey=[key value]')
         }
+        buildConfigField("String", "BASE64_ENCODED_PUBLIC_KEY", "\"" + localProperties['base64EncodedPublicKey'] + "\"")
     }
     buildTypes {
         release {

--- a/TrivialDriveJava/app/src/main/java/com/sample/android/trivialdrivesample/ui/MainActivity.java
+++ b/TrivialDriveJava/app/src/main/java/com/sample/android/trivialdrivesample/ui/MainActivity.java
@@ -16,15 +16,20 @@
 
 package com.sample.android.trivialdrivesample.ui;
 
+import android.app.Dialog;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.databinding.DataBindingUtil;
+import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
@@ -32,6 +37,7 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.sample.android.trivialdrivesample.BuildConfig;
 import com.sample.android.trivialdrivesample.MainActivityViewModel;
 import com.sample.android.trivialdrivesample.R;
 import com.sample.android.trivialdrivesample.TrivialDriveApplication;
@@ -77,6 +83,15 @@ public class MainActivity extends AppCompatActivity {
         });
         // Allows billing to refresh purchases during onResume
         getLifecycle().addObserver(mainActivityViewModel.getBillingLifecycleObserver());
+
+        // A helpful hint to prevent confusion when billing transactions silently fail
+        if ( BuildConfig.BASE64_ENCODED_PUBLIC_KEY.equals("null")) {
+            if ( getSupportFragmentManager()
+                    .findFragmentByTag(PublicKeyNotSetDialog.DIALOG_TAG) == null ) {
+                new PublicKeyNotSetDialog()
+                        .show(getSupportFragmentManager(), PublicKeyNotSetDialog.DIALOG_TAG);
+            }
+        }
     }
 
     @Override
@@ -95,6 +110,22 @@ public class MainActivity extends AppCompatActivity {
             return true;
         } else {
             return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static class PublicKeyNotSetDialog extends DialogFragment {
+        static final String DIALOG_TAG = "PublicKeyNotSetDialog";
+        @NonNull
+        @Override
+        public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+            return new AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.alert_error_title_encoded_public_key_not_set)
+                    .setMessage(
+                            R.string.alert_error_message_encoded_public_key_not_set)
+                    .setPositiveButton(getString(android.R.string.ok),
+                            (dialog, which) -> {
+                            })
+                    .create();
         }
     }
 }

--- a/TrivialDriveJava/app/src/main/res/values/strings.xml
+++ b/TrivialDriveJava/app/src/main/res/values/strings.xml
@@ -43,4 +43,11 @@
     <string name="debug_description_not_found">Make sure that you have uploaded an APK to the Google Play developer console, that the correct SKUs have been created for the APK, and the signed-in account has been enabled for testing.</string>
 
     <string name="error_unable_to_make_purchase">Unable to make purchase.</string>
+
+    <string name="alert_error_message_encoded_public_key_not_set">base64EncodedPublicKey
+        <b>must</b> be set for signature verification. You can add it to <b>local.properties</b>
+        once you have gotten it from Play.\n\n<b>Example: <tt>base64EncodedPublicKey=[key value]</tt>
+        </b></string>
+    <string name="alert_error_title_encoded_public_key_not_set">Public Key Not Set</string>
+
 </resources>

--- a/TrivialDriveKotlin/app/build.gradle
+++ b/TrivialDriveKotlin/app/build.gradle
@@ -30,13 +30,12 @@ android {
                                       "$projectDir/schemas".toString()]
             }
         }
-        if (localProperties['base64EncodedPublicKey']) {
-            buildConfigField("String", "BASE64_ENCODED_PUBLIC_KEY", "\"" + localProperties['base64EncodedPublicKey'] + "\"")
-        } else {
-            throw new GradleException('base64EncodedPublicKey must be set for signature verification.' +
-                    'You can add it to local.properties once you have gotten it from Play.' +
+        if (!localProperties['base64EncodedPublicKey']) {
+            logger.warn('base64EncodedPublicKey must be set for signature verification. ' +
+                    'You can add it to local.properties once you have gotten it from Play. ' +
                     'Example: base64EncodedPublicKey=[key value]')
         }
+        buildConfigField("String", "BASE64_ENCODED_PUBLIC_KEY", "\"" + localProperties['base64EncodedPublicKey'] + "\"")
     }
     buildTypes {
         release {

--- a/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/ui/MainActivity.java
+++ b/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/ui/MainActivity.java
@@ -16,15 +16,20 @@
 
 package com.sample.android.trivialdrivesample.ui;
 
+import android.app.Dialog;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.databinding.DataBindingUtil;
+import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
@@ -32,6 +37,7 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.sample.android.trivialdrivesample.BuildConfig;
 import com.sample.android.trivialdrivesample.MainActivityViewModel;
 import com.sample.android.trivialdrivesample.R;
 import com.sample.android.trivialdrivesample.TrivialDriveApplication;
@@ -44,6 +50,7 @@ import com.sample.android.trivialdrivesample.databinding.ActivityMainBinding;
 public class MainActivity extends AppCompatActivity{
     private MainActivityViewModel mainActivityViewModel;
     private ActivityMainBinding activityMainBinding;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -76,6 +83,15 @@ public class MainActivity extends AppCompatActivity{
         });
         // Allows billing to refresh purchases during onResume
         getLifecycle().addObserver(mainActivityViewModel.getBillingLifecycleObserver());
+
+        // A helpful hint to prevent confusion when billing transactions silently fail
+        if ( BuildConfig.BASE64_ENCODED_PUBLIC_KEY.equals("null")) {
+            if ( getSupportFragmentManager()
+                    .findFragmentByTag(PublicKeyNotSetDialog.DIALOG_TAG) == null ) {
+                new PublicKeyNotSetDialog()
+                        .show(getSupportFragmentManager(), PublicKeyNotSetDialog.DIALOG_TAG);
+            }
+        }
     }
 
     @Override
@@ -95,5 +111,21 @@ public class MainActivity extends AppCompatActivity{
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    public static class PublicKeyNotSetDialog extends DialogFragment {
+        static final String DIALOG_TAG = "PublicKeyNotSetDialog";
+        @NonNull
+        @Override
+        public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+            return new AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.alert_error_title_encoded_public_key_not_set)
+                    .setMessage(
+                            R.string.alert_error_message_encoded_public_key_not_set)
+                    .setPositiveButton(getString(android.R.string.ok),
+                            (dialog, which) -> {
+                            })
+                    .create();
+        }
     }
 }

--- a/TrivialDriveKotlin/app/src/main/res/values/strings.xml
+++ b/TrivialDriveKotlin/app/src/main/res/values/strings.xml
@@ -43,4 +43,10 @@
     <string name="debug_description_not_found">Make sure that you have uploaded an APK to the Google Play developer console, that the correct SKUs have been created for the APK, and the signed-in account has been enabled for testing.</string>
 
     <string name="error_unable_to_make_purchase">Unable to make purchase.</string>
+
+    <string name="alert_error_message_encoded_public_key_not_set">base64EncodedPublicKey
+        <b>must</b> be set for signature verification. You can add it to <b>local.properties</b>
+        once you have gotten it from Play.\n\n<b>Example: <tt>base64EncodedPublicKey=[key value]</tt>
+        </b></string>
+    <string name="alert_error_title_encoded_public_key_not_set">Public Key Not Set</string>
 </resources>


### PR DESCRIPTION
Display a dialog instead of causing the build to fail if no base64EncodedPublicKey in local.properties.

* This allows the current code to build and run in CI environments without having to have local.properties set, while still informing the developer of what needs to happen to fix things.
* Warning will also print in Gradle build.