### PR TITLE
Removed unused MakePurchaseViewModel reference

### DIFF
--- a/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/billing/BillingDataSource.kt
+++ b/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/billing/BillingDataSource.kt
@@ -39,7 +39,6 @@ import com.android.billingclient.api.acknowledgePurchase
 import com.android.billingclient.api.consumePurchase
 import com.android.billingclient.api.queryPurchasesAsync
 import com.android.billingclient.api.querySkuDetails
-import com.sample.android.trivialdrivesample.MakePurchaseViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow


### PR DESCRIPTION
ViewModel reference in a Repository is an antipattern. In this case, the import is unused.