### PR TITLE
When no subscriptions are active, the empty list must be shared with the rest of the system

### DIFF
--- a/ClassyTaxiAppKotlin/app/src/main/java/com/example/subscriptions/data/network/retrofit/RemoteServerFunctionsImpl.kt
+++ b/ClassyTaxiAppKotlin/app/src/main/java/com/example/subscriptions/data/network/retrofit/RemoteServerFunctionsImpl.kt
@@ -230,7 +230,7 @@ class RemoteServerFunctionsImpl : ServerFunctions {
         subscriptions: MutableLiveData<List<SubscriptionStatus>>
     ) {
         val subs = responseBody["subscriptions"] as List<*>?
-        if (subs == null || subs.isEmpty()) {
+        if (subs == null) {
             Log.w(TAG, "Invalid subscription data")
             return
         }

--- a/ClassyTaxiJava/app/src/main/java/com/sample/android/classytaxijava/data/network/retrofit/ServerFunctionImpl.java
+++ b/ClassyTaxiJava/app/src/main/java/com/sample/android/classytaxijava/data/network/retrofit/ServerFunctionImpl.java
@@ -289,7 +289,7 @@ public class ServerFunctionImpl implements ServerFunctions {
      */
     protected void onSuccessfulSubscriptionCall(Map<String, Object> responseBody, @Nullable MutableLiveData<List<SubscriptionStatus>> subscriptions) {
         List subs = (List) responseBody.get("subscriptions");
-        if (subs.isEmpty()) {
+        if (subs == null) {
             Log.w(TAG, "Invalid subscription data");
             return;
         }


### PR DESCRIPTION
When all subscriptions are lapsed (canceled, implicitly or explicitly) we need the empty list to be shared with the rest of the system, otherwise the Android app's cached perspective never gets changed and it looks like the last valid subscription is still active.

Fix is to fail when the response's "subscription" field is absent, *not* when it is simply empty.