### PR TITLE
Avoid processing an empty purchase object

### DIFF
--- a/TrivialDriveJava/app/src/main/java/com/sample/android/trivialdrivesample/billing/BillingDataSource.java
+++ b/TrivialDriveJava/app/src/main/java/com/sample/android/trivialdrivesample/billing/BillingDataSource.java
@@ -590,7 +590,7 @@ public class BillingDataSource implements LifecycleObserver, PurchasesUpdatedLis
      */
     private void processPurchaseList(List<Purchase> purchases, List<String> skusToUpdate) {
         HashSet<String> updatedSkus = new HashSet<>();
-        if (null != purchases) {
+        if (null != purchases && !purchases.isEmpty()) {
             for (final Purchase purchase : purchases) {
                 for (String sku : purchase.getSkus()) {
                     final MutableLiveData<SkuState> skuStateLiveData = skuStateMap.get(sku);


### PR DESCRIPTION
When purchase object is not null but is empty, incorrectly gets passed to processing. Instead empty purchase object should get passed into already defined else statement, "Empty purchase list."