### PR TITLE
Fix project not compatible with apple silicon

### DIFF
--- a/TrivialDriveJava/app/build.gradle
+++ b/TrivialDriveJava/app/build.gradle
@@ -17,13 +17,13 @@ android {
             storePassword "${password}"
         }*/
     }
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion '30.0.3'
 
     defaultConfig {
         applicationId 'com.sample.android.trivialdrivesample'
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 8
         versionName "1.5"
         javaCompileOptions {

--- a/TrivialDriveJava/app/src/main/AndroidManifest.xml
+++ b/TrivialDriveJava/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name="com.sample.android.trivialdrivesample.ui.MainActivity"
-            android:label="@string/title_game_fragment">
+            android:label="@string/title_game_fragment"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/TrivialDriveJava/build.gradle
+++ b/TrivialDriveJava/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
     }
     ext {
-        version_room = "2.3.0"
+        version_room = "2.4.2"
         version_navigation = "2.3.5"
         version_billing = "4.0.0"
         version_lifecycle = "2.3.1"


### PR DESCRIPTION
Updates `androidx.room:room-runtime` to version `2.4.2`. The target and compile sdk versions have also been bumped up to version 31 (minimum requirement on room 2.4.0+). This fixes room not working on apple silicon-based computers for the TrivialDriveJava app.

Fixes #553 